### PR TITLE
Landmark Index Dict Consistency

### DIFF
--- a/imutils/face_utils/helpers.py
+++ b/imutils/face_utils/helpers.py
@@ -20,9 +20,9 @@ FACIAL_LANDMARKS_68_IDXS = OrderedDict([
 
 #For dlib’s 5-point facial landmark detector:
 FACIAL_LANDMARKS_5_IDXS = OrderedDict([
-	("right_eye", (2, 3)),
-	("left_eye", (0, 1)),
-	("nose", (4))
+	("right_eye", (2, 4)),
+	("left_eye", (0, 2)),
+	("nose", 4)
 ])
 
 # in order to support legacy code, we'll default the indexes to the


### PR DESCRIPTION
The 5-landmark dict has a different indexing definition. This makes it difficult to write code that works with both the 5-landmark and 68-landmark dlib detectors.

For example, this:
```
left_eye_start, left_eye_end = FACIAL_LANDMARKS_68_IDXS["left_eye"]
left_eye_landmarks = features[left_eye_start:left_eye_end]
```

is not the same as this:
```
left_eye_start, left_eye_end = FACIAL_LANDMARKS_5_IDXS["left_eye"]
left_eye_landmarks = features[left_eye_start:left_eye_end]
```

The latter only gives one of the left eye landmark positions, rather than both as desired