### PR TITLE
fix FileVideoStream last frame being None

### DIFF
--- a/imutils/video/filevideostream.py
+++ b/imutils/video/filevideostream.py
@@ -50,6 +50,7 @@ class FileVideoStream:
 				# reached the end of the video file
 				if not grabbed:
 					self.stopped = True
+					break
 					
 				# if there are transforms to be done, might as well
 				# do them on producer thread before handing back to


### PR DESCRIPTION
When FileVideoStream reaches the end of the file, it takes one more frame (which is NoneType) and tries to transform and add it to the queue. This causes an error if the transform expects a valid frame, or if the main script does not expect the last frame in the Queue to be NoneType.
This has also been noted in issue #251 . 