### PR TITLE
Changing 'angle' in rotate_bound() from negative to positive to unify…

### DIFF
--- a/imutils/convenience.py
+++ b/imutils/convenience.py
@@ -47,7 +47,7 @@ def rotate_bound(image, angle):
     # grab the rotation matrix (applying the negative of the
     # angle to rotate clockwise), then grab the sine and cosine
     # (i.e., the rotation components of the matrix)
-    M = cv2.getRotationMatrix2D((cX, cY), -angle, 1.0)
+    M = cv2.getRotationMatrix2D((cX, cY), angle, 1.0)
     cos = np.abs(M[0, 0])
     sin = np.abs(M[0, 1])
 


### PR DESCRIPTION
… it with rotate() funciton.

Since definition of rotation matrix around specific axis is that the positive angle is counter clockwise rotation, I guess it should be like this in rotate_bound() function. Additionally consider that in rotate() function angle is counter clockwise, so making it the same in rotate_bound() would unify the library.